### PR TITLE
Add HLT trigger path selection

### DIFF
--- a/python/postprocessing/VBFHToInvModules.py
+++ b/python/postprocessing/VBFHToInvModules.py
@@ -7,7 +7,7 @@ from VBFHToInv.NanoAODTools.postprocessing.modules.jetMetmindphi import JetMetMi
 from VBFHToInv.NanoAODTools.postprocessing.modules.MetCleaning import MetCleaningConstructor
 from VBFHToInv.NanoAODTools.postprocessing.modules.lepSFProducer import lepSFtight
 from VBFHToInv.NanoAODTools.postprocessing.modules.lepSFProducer import lepSFveto
-
+from VBFHToInv.NanoAODTools.postprocessing.modules.trigger_selection import TriggerSelectionConstructor
 
 #btagging weights - give event weight automatically based on jets discri (so all working points automatically)
 from PhysicsTools.NanoAODTools.postprocessing.modules.btv.btagSFProducer import btagSF2017

--- a/python/postprocessing/modules/trigger_selection.py
+++ b/python/postprocessing/modules/trigger_selection.py
@@ -1,0 +1,90 @@
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.tools import *
+
+class TriggerSelection(Module):
+    def __init__(self):
+        self.HLT_signal_trigger_paths = [
+            "HLT_PFMET110_PFMHT110_IDTight",
+            "HLT_PFMET120_PFMHT120_IDTight",
+            "HLT_PFMET130_PFMHT130_IDTight",
+            "HLT_PFMET140_PFMHT140_IDTight",
+
+            "HLT_PFMET100_PFMHT100_IDTight_PFHT60",
+            "HLT_PFMET120_PFMHT120_IDTight_PFHT60",
+
+            "HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_PFHT60",
+            "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60",
+
+            "HLT_PFMETTypeOne100_PFMHT100_IDTight_PFHT60",
+            "HLT_PFMETTypeOne120_PFMHT120_IDTight_PFHT60",
+
+            "HLT_PFMETTypeOne110_PFMHT110_IDTight",
+            "HLT_PFMETTypeOne120_PFMHT120_IDTight",
+            "HLT_PFMETTypeOne130_PFMHT130_IDTight",
+            "HLT_PFMETTypeOne140_PFMHT140_IDTight",
+
+            "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight",
+            "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight",
+            "HLT_PFMETNoMu130_PFMHTNoMu130_IDTight",
+            "HLT_PFMETNoMu140_PFMHTNoMu140_IDTight",
+
+            "HLT_PFHT1050",
+
+            "HLT_DiJet110_35_Mjj650_PFMET110",
+            "HLT_DiJet110_35_Mjj650_PFMET120",
+            "HLT_DiJet110_35_Mjj650_PFMET130",
+            "HLT_TripleJet110_35_35_Mjj650_PFMET110",
+            "HLT_TripleJet110_35_35_Mjj650_PFMET120",
+            "HLT_TripleJet110_35_35_Mjj650_PFMET130",
+
+            "HLT_PFHT500_PFMET100_PFMHT100_IDTight",
+            "HLT_PFHT500_PFMET110_PFMHT110_IDTight",
+            "HLT_PFHT700_PFMET85_PFMHT85_IDTight",
+            "HLT_PFHT700_PFMET95_PFMHT95_IDTight",
+            "HLT_PFHT800_PFMET75_PFMHT75_IDTight",
+            "HLT_PFHT800_PFMET85_PFMHT85_IDTight",
+        ]
+
+        self.HLT_control_trigger_paths = [
+            "HLT_IsoMu27",
+
+            "MET_MHT",
+
+            "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight",
+            "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight",
+            "HLT_PFMETNoMu130_PFMHTNoMu130_IDTight",
+            "HLT_PFMETNoMu140_PFMHTNoMu140_IDTight",
+
+            "HLT_PFMETNoMu100_PFMHTNoMu100_IDTight_PFHT60",
+            "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_PFHT60",
+
+            "HLT_PFHT1050",
+        ]
+
+
+    def beginJob(self):
+        pass
+    def endJob(self):
+        pass
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+        for trigger in self.HLT_signal_trigger_paths + self.HLT_control_trigger_paths:
+            try:
+                trig_check = getattr(event, trigger)
+                if trig_check == 1:
+                    return True # event passes selection
+            except (AttributeError, RuntimeError), e:
+                #Trigger path does not exist in this file
+                continue
+        return False # if no triggers pass          
+
+
+TriggerSelectionConstructor = lambda : TriggerSelection()

--- a/python/postprocessing/modules/trigger_selection.py
+++ b/python/postprocessing/modules/trigger_selection.py
@@ -51,8 +51,6 @@ class TriggerSelection(Module):
         self.HLT_control_trigger_paths = [
             "HLT_IsoMu27",
 
-            "MET_MHT",
-
             "HLT_PFMETNoMu110_PFMHTNoMu110_IDTight",
             "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight",
             "HLT_PFMETNoMu130_PFMHTNoMu130_IDTight",


### PR DESCRIPTION
Currently just an OR of the HLT trigger paths in the lists `HLT_signal_trigger_paths` and `HLT_control_trigger_paths`. If any trigger path exists in the root file _and_ its value is 1, the event passes. If a trigger path in one of the lists does not exist in the root file, the loop just skips that trigger.